### PR TITLE
Fix modal state persistence and queue processing timing

### DIFF
--- a/components/features/ConflictResolutionModal.tsx
+++ b/components/features/ConflictResolutionModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { format } from "date-fns";
 import { useMutation } from "convex/react";
@@ -75,6 +75,15 @@ export function ConflictResolutionModal({
     new Date(queue.nextScheduledTime)
   );
   const updateQueue = useMutation(api.queues.updateQueue);
+
+  // Reset newScheduledTime when the queue changes
+  useEffect(() => {
+    if (queue.nextScheduledTime) {
+      setNewScheduledTime(new Date(queue.nextScheduledTime));
+    } else {
+      setNewScheduledTime(undefined);
+    }
+  }, [queue.nextScheduledTime]);
 
   // Filter conflicts for this queue
   const queueConflicts = conflicts.filter((c) => c.queueId === queue._id);

--- a/components/features/QueueList.tsx
+++ b/components/features/QueueList.tsx
@@ -63,9 +63,14 @@ export function QueueList() {
     if (highlight) {
       setHighlightedQueueId(highlight);
       // Clear highlight after 2 seconds
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         setHighlightedQueueId(null);
       }, 2000);
+
+      // Cleanup: clear timeout on unmount or when searchParams changes
+      return () => {
+        clearTimeout(timer);
+      };
     }
   }, [searchParams]);
 

--- a/convex/queues.ts
+++ b/convex/queues.ts
@@ -801,21 +801,15 @@ export const processQueues = internalMutation({
 /**
  * Cron job configuration for recurring queue processing
  *
- * This cron job runs daily at midnight UTC to process due recurring queues.
- * For more frequent processing, switch to crons.hourly().
+ * This cron job runs every 5 minutes to process due recurring queues.
+ * This ensures queues scheduled throughout the day are picked up promptly
+ * instead of waiting until the next daily run.
  */
 export const crons = cronJobs();
 
-// Run processQueues daily at midnight UTC (12:00 AM)
-crons.daily(
+// Run processQueues every 5 minutes
+crons.interval(
   "process-recurring-queues",
-  { hourUTC: 0, minuteUTC: 0 },
+  { minutes: 5 },
   internal.queues.processQueues
 );
-
-// Alternative: Hourly processing (uncomment to use)
-// crons.hourly(
-//   "process-recurring-queues",
-//   { minuteUTC: 0 },
-//   internal.queues.processQueues
-// );


### PR DESCRIPTION
## Summary

This PR fixes three critical issues related to state management and queue processing:

- **ConflictResolutionModal**: Time picker now properly resets when switching between queues
- **QueueList**: Fixed memory leak from uncleaned timeout that could cause state updates after unmount  
- **Queue Processing**: Changed from daily (midnight UTC) to 5-minute intervals for timely execution

## Changes

### 1. ConflictResolutionModal.tsx
- Added `useEffect` hook that watches `queue.nextScheduledTime`
- Resets `newScheduledTime` state when modal opens for a different queue
- Prevents stale time values from persisting across queue changes

### 2. QueueList.tsx  
- Stored timeout ID in `timer` constant
- Added cleanup function that calls `clearTimeout(timer)`
- Prevents memory leaks and state updates after component unmount
- Clears existing timer when searchParams changes

### 3. convex/queues.ts
- Replaced `crons.daily()` with `crons.interval()` 
- Changed from once daily (midnight UTC) to every 5 minutes
- Ensures queues scheduled throughout the day are processed promptly
- Updated comments to reflect new 5-minute cadence

## Test plan

- [ ] Open ConflictResolutionModal for one queue, note the time
- [ ] Close and open for a different queue - verify time updates correctly
- [ ] Navigate away from QueueList page while highlight is active - verify no console errors
- [ ] Verify queue processing runs every 5 minutes (check Convex dashboard cron logs)
- [ ] Schedule a queue for a specific time and verify it processes within 5 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)